### PR TITLE
Modify doInit() to print plugin defined logo.

### DIFF
--- a/xpocket-runtime/src/main/java/com/perfma/xlab/xpocket/framework/spi/impl/DefaultPluginContext.java
+++ b/xpocket-runtime/src/main/java/com/perfma/xlab/xpocket/framework/spi/impl/DefaultPluginContext.java
@@ -10,6 +10,7 @@ import com.perfma.xlab.xpocket.spi.process.XPocketProcess;
 import com.perfma.xlab.xpocket.utils.AsciiArtUtil;
 import java.lang.instrument.Instrumentation;
 
+import java.lang.reflect.Field;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -171,10 +172,16 @@ public class DefaultPluginContext implements FrameworkPluginContext {
                 if(PluginType.JAVA_AGENT == type && inst != null) {
                     ((XPocketAgentPlugin)plugin).init(process, inst, isOnLoad);
                 }
-                
-                logo = plugin.logo();
-                
-                if(logo == null) {
+
+                //获取插件自定义LOGO
+                Field logoField = pluginClass.getDeclaredField("LOGO");
+                logoField.setAccessible(true);
+                if (logoField.get(pluginClass).toString().length() > 0){
+                    logo = logoField.get(pluginClass).toString();
+                }
+                //logo = plugin.logo();
+
+                if(logo == null || logo.isEmpty()) {
                     StringBuilder text = new StringBuilder(name.length() * 2);
                     
                     for(char c : name.toUpperCase().toCharArray()) {

--- a/xpocket-runtime/src/main/java/com/perfma/xlab/xpocket/framework/spi/impl/DefaultPluginContext.java
+++ b/xpocket-runtime/src/main/java/com/perfma/xlab/xpocket/framework/spi/impl/DefaultPluginContext.java
@@ -174,10 +174,13 @@ public class DefaultPluginContext implements FrameworkPluginContext {
                 }
 
                 //获取插件自定义LOGO
-                Field logoField = pluginClass.getDeclaredField("LOGO");
-                logoField.setAccessible(true);
-                if (logoField.get(pluginClass).toString().length() > 0){
-                    logo = logoField.get(pluginClass).toString();
+                Field[] fields = pluginClass.getDeclaredFields();
+
+                for (Field field : fields) {
+                    field.setAccessible(true);
+                    if (field.getName().equals("LOGO") && field.get(pluginClass).toString().length() > 0){
+                        logo = field.get(pluginClass).toString();
+                    }
                 }
                 //logo = plugin.logo();
 


### PR DESCRIPTION
之前的DefaultPluginContext的doInit()方法中，logo = plugin.logo()获取不到插件自定义的Logo，只能输出AsciiArtUtil.text2AsciiArt格式的Logo . 修改后可以读取到plugin自定义的Logo并输出.