### PR TITLE
[ISSUE #43] Change the version on which the module depends

### DIFF
--- a/xpocket-framework-spi/pom.xml
+++ b/xpocket-framework-spi/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.perfma.xlab</groupId>
             <artifactId>xpocket-jline</artifactId>
-            <version>2.1.0-RELEASE</version>
+            <version>2.1.1-RELEASE</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
xpocket-framework-spi depends  xpocket-jline 2.1.0-RELEASE change to 2.1.1-RELEASE